### PR TITLE
Fix missing ENTRYPOINT in language-specific Docker images

### DIFF
--- a/docker-images/cpp/Dockerfile
+++ b/docker-images/cpp/Dockerfile
@@ -64,3 +64,7 @@ USER student
 RUN conan profile detect --force
 
 WORKDIR /workspace
+
+# Inherit entrypoint from base image
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["code-server", "--bind-addr", "0.0.0.0:8080", "--auth", "password", "/workspace"]

--- a/docker-images/java/Dockerfile
+++ b/docker-images/java/Dockerfile
@@ -41,3 +41,7 @@ RUN mkdir -p /home/student/.m2 && \
 </settings>' > /home/student/.m2/settings.xml
 
 WORKDIR /workspace
+
+# Inherit entrypoint from base image
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["code-server", "--bind-addr", "0.0.0.0:8080", "--auth", "password", "/workspace"]

--- a/docker-images/nodejs/Dockerfile
+++ b/docker-images/nodejs/Dockerfile
@@ -48,3 +48,7 @@ ENV NODE_ENV=development \
     PATH="/home/student/.npm-global/bin:${PATH}"
 
 WORKDIR /workspace
+
+# Inherit entrypoint from base image
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["code-server", "--bind-addr", "0.0.0.0:8080", "--auth", "password", "/workspace"]

--- a/docker-images/python/Dockerfile
+++ b/docker-images/python/Dockerfile
@@ -55,3 +55,7 @@ RUN python -m venv /home/student/venv
 ENV PATH="/home/student/venv/bin:$PATH"
 
 WORKDIR /workspace
+
+# Inherit entrypoint from base image
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["code-server", "--bind-addr", "0.0.0.0:8080", "--auth", "password", "/workspace"]

--- a/docker-images/sql/Dockerfile
+++ b/docker-images/sql/Dockerfile
@@ -212,3 +212,7 @@ fi\n\
 ' >> /home/student/.bashrc
 
 WORKDIR /workspace
+
+# Inherit entrypoint from base image
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["code-server", "--bind-addr", "0.0.0.0:8080", "--auth", "password", "/workspace"]


### PR DESCRIPTION
All language-specific Docker images (Python, Java, C++, Node.js, SQL) were missing the ENTRYPOINT and CMD instructions, causing containers to fail with "exec /usr/local/bin/entrypoint.sh: no such file or directory" error.

While these instructions are defined in the base image, they need to be explicitly re-declared in derived images to ensure proper inheritance.

Changes:
- Added ENTRYPOINT and CMD to docker-images/python/Dockerfile
- Added ENTRYPOINT and CMD to docker-images/java/Dockerfile
- Added ENTRYPOINT and CMD to docker-images/cpp/Dockerfile
- Added ENTRYPOINT and CMD to docker-images/nodejs/Dockerfile
- Added ENTRYPOINT and CMD to docker-images/sql/Dockerfile

Fixes #3