### PR TITLE
fix: add Python3 and pip to SQL Docker image

### DIFF
--- a/docker-images/sql/Dockerfile
+++ b/docker-images/sql/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && apt-get install -y \
     sqlite3 \
     gnupg \
     wget \
+    python3 \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install MongoDB


### PR DESCRIPTION
The SQL Dockerfile was failing because it tried to use pip3 without having Python installed. Added python3 and python3-pip packages to fix the build error.

Fixes #16