### PR TITLE
fix: Add chown for SQLite directory to fix permissions

### DIFF
--- a/docker-images/sql/Dockerfile
+++ b/docker-images/sql/Dockerfile
@@ -62,7 +62,8 @@ RUN mkdir -p /home/student/postgres && \
     chown -R student:student /home/student/postgres
 
 # Initialize SQLite sample database
-RUN mkdir -p /home/student/databases/sqlite
+RUN mkdir -p /home/student/databases/sqlite && \
+    chown -R student:student /home/student/databases/sqlite
 
 # Initialize MongoDB data directory
 RUN mkdir -p /home/student/mongodb/data /home/student/mongodb/logs && \


### PR DESCRIPTION
The SQLite directory was created as root but the student user needed write permissions to create the database file. This fix adds the chown command to transfer ownership to the student user.

Fixes #18