### PR TITLE
fix: add --break-system-packages flag to Python Docker image

### DIFF
--- a/docker-images/python/Dockerfile
+++ b/docker-images/python/Dockerfile
@@ -21,7 +21,7 @@ RUN \
   ln -sf /usr/bin/python3 /usr/bin/python && \
   ln -sf /usr/bin/pip3 /usr/bin/pip && \
   echo "**** install common Python packages ****" && \
-  pip install --no-cache-dir \
+  pip install --no-cache-dir --break-system-packages \
     numpy \
     pandas \
     matplotlib \


### PR DESCRIPTION
Resolves externally-managed-environment error when installing Python packages.

Modern Python distributions (Debian 12/Ubuntu 23.04+) implement PEP 668 which prevents direct pip installations to avoid conflicts with system packages.

Fixes #21

---
Generated with [Claude Code](https://claude.ai/code)