### PR TITLE
fix: resolve Docker build failures with tag format and user creation

### DIFF
--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -63,6 +63,12 @@ ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8
 
+# Create student user and group
+RUN groupadd -g 1000 student && \
+    useradd -u 1000 -g 1000 -m -s /bin/bash student && \
+    echo "student:changeme" | chpasswd && \
+    usermod -aG sudo student
+
 # Add local files (s6-overlay configuration)
 COPY /root /
 


### PR DESCRIPTION
- Fixed invalid tag format in docker-build.yml by removing branch prefix from SHA tags
- Added student user creation (UID/GID 1000) to base Dockerfile
- This resolves chown failures in language-specific images

Fixes #23