### PR TITLE
fix: resolve npm permission error in nodejs Docker image

### DIFF
--- a/docker-images/nodejs/Dockerfile
+++ b/docker-images/nodejs/Dockerfile
@@ -32,16 +32,17 @@ RUN npm install -g \
 # Install VS Code JavaScript/TypeScript extensions
 ENV VSCODE_EXTENSIONS="dbaeumer.vscode-eslint,esbenp.prettier-vscode,ms-vscode.vscode-typescript-next,christian-kohler.npm-intellisense,eg2.vscode-npm-script,formulahendry.auto-rename-tag,formulahendry.auto-close-tag"
 
-# Create npm directories
-RUN mkdir -p /home/student/.npm /home/student/.yarn /home/student/.pnpm && \
-    chown -R student:student /home/student/.npm /home/student/.yarn /home/student/.pnpm
+# Create npm directories and configure npm as root
+RUN mkdir -p /home/student/.npm /home/student/.yarn /home/student/.pnpm /home/student/.npm-global && \
+    chown -R student:student /home/student/.npm /home/student/.yarn /home/student/.pnpm /home/student/.npm-global && \
+    npm config set cache /home/student/.npm --global && \
+    echo 'export PATH=/home/student/.npm-global/bin:$PATH' >> /home/student/.bashrc
 
 # Switch back to student user
 USER student
 
-# Configure npm
-RUN npm config set prefix /home/student/.npm-global && \
-    echo 'export PATH=/home/student/.npm-global/bin:$PATH' >> /home/student/.bashrc
+# Configure npm prefix as student user
+RUN npm config set prefix /home/student/.npm-global
 
 # Set Node environment variables
 ENV NODE_ENV=development \


### PR DESCRIPTION
## Summary
Fixed EACCES permission error in the nodejs Docker image build.

## Changes
- Create .npm-global directory as root before switching to student user
- Set global npm cache location to student-owned directory
- Configure npm prefix as student user to avoid EACCES errors

Fixes #27

Generated with [Claude Code](https://claude.ai/code)