### PR TITLE
fix: resolve npm permission error in nodejs Dockerfile

### DIFF
--- a/docker-images/nodejs/Dockerfile
+++ b/docker-images/nodejs/Dockerfile
@@ -35,14 +35,14 @@ ENV VSCODE_EXTENSIONS="dbaeumer.vscode-eslint,esbenp.prettier-vscode,ms-vscode.v
 # Create npm directories and configure npm as root
 RUN mkdir -p /home/student/.npm /home/student/.yarn /home/student/.pnpm /home/student/.npm-global && \
     chown -R student:student /home/student/.npm /home/student/.yarn /home/student/.pnpm /home/student/.npm-global && \
-    npm config set cache /home/student/.npm --global && \
     echo 'export PATH=/home/student/.npm-global/bin:$PATH' >> /home/student/.bashrc
 
 # Switch back to student user
 USER student
 
-# Configure npm prefix as student user
-RUN npm config set prefix /home/student/.npm-global
+# Configure npm for student user
+RUN npm config set prefix /home/student/.npm-global && \
+    npm config set cache /home/student/.npm
 
 # Set Node environment variables
 ENV NODE_ENV=development \


### PR DESCRIPTION
Fixes #31

This PR resolves the Docker build failure for the nodejs image caused by an npm permission error.

### Changes
- Removed `--global` flag from npm config command in nodejs Dockerfile
- Moved npm cache configuration to run as student user instead of root
- Both npm prefix and cache are now configured at user-level, avoiding permission issues

### Root Cause
The build was failing because npm was trying to write to `/config/.npmrc` (global config) as the student user, which didn't have the necessary permissions.

Generated with [Claude Code](https://claude.ai/code)