### PR TITLE
fix: Add --break-system-packages flag to pip install conan

### DIFF
--- a/docker-images/cpp/Dockerfile
+++ b/docker-images/cpp/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \
     ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg
 
 # Install Conan package manager
-RUN pip3 install conan
+RUN pip3 install --break-system-packages conan
 
 # Install VS Code C++ extensions
 ENV VSCODE_EXTENSIONS="ms-vscode.cpptools,ms-vscode.cpptools-extension-pack,ms-vscode.cmake-tools,twxs.cmake,jeff-hykin.better-cpp-syntax"


### PR DESCRIPTION
## Summary
Fixed the cpp Docker image build failure by adding the `--break-system-packages` flag to the `pip3 install conan` command.

## Details
The build was failing with an "externally-managed-environment" error due to PEP 668, which prevents pip from modifying system-managed Python packages. The `--break-system-packages` flag bypasses this restriction, which is safe and appropriate in a Docker container context.

Fixes #34

Generated with [Claude Code](https://claude.ai/code)